### PR TITLE
fix: make axum_url public for typed_uri macro

### DIFF
--- a/lazybe-macros/src/typed_uri.rs
+++ b/lazybe-macros/src/typed_uri.rs
@@ -112,7 +112,7 @@ fn expand_axum_url(uri_meta: &TypedUriMeta) -> TokenStream {
 
     quote! {
         impl #ident {
-            const AXUM_PATH: &str = concat!(#(#str_segments),*);
+            pub const AXUM_PATH: &str = concat!(#(#str_segments),*);
         }
     }
 }


### PR DESCRIPTION
This allow uri to be defined in another module.